### PR TITLE
Updating Archetype.Entities to Archetype.EntityCount

### DIFF
--- a/Arch Entity Debugger/Scripts/EntityDebugger.cs
+++ b/Arch Entity Debugger/Scripts/EntityDebugger.cs
@@ -188,7 +188,7 @@ public partial class EntityDebugger : Control
                 archetypeKey = stringBuilder.ToString();
             }
 
-            if (archetype.Entities == 0)
+            if (archetype.EntityCount == 0)
             {
                 if (archetypeItems.ContainsKey(archetypeKey))
                 {
@@ -230,7 +230,7 @@ public partial class EntityDebugger : Control
             }
 
             TreeItem archetypeItem = parentItem;
-            archetypeItem.SetText(1, archetype.Entities.ToString());
+            archetypeItem.SetText(1, archetype.EntityCount.ToString());
 
             foreach (ref Chunk chunk in archetype)
             {


### PR DESCRIPTION
Minor change: in the current Arch source code, the Archetype parameter Entities has been renamed to EntityCount, which causes this addon to fail to build. Commit can be found [here](https://github.com/genaray/Arch/commit/d7340182cf45914e8c5b4eb22114fdc81f4e775f#diff-bc246cfde06d5e3b166fcfce1c792c36ef45e5c9f86acddaf174b97f35462d5a).

Note: this change is not yet in a release for Arch (though it does seem to me like a sensible change that is likely to remain). Feel free to delay approval until it is in a release if you'd prefer.