### PR TITLE
Update for Arch 2.0.0

### DIFF
--- a/Arch Entity Debugger/Scripts/EntityDebugger.cs
+++ b/Arch Entity Debugger/Scripts/EntityDebugger.cs
@@ -21,7 +21,7 @@ public partial class EntityDebugger : Control
     private PackedScene debugWindowPrefab;
     private Window debugWindow;
 
-    private EntityReference selectedEntity = EntityReference.Null;
+    private Entity selectedEntity = Entity.Null;
 
     private double timer;
 
@@ -44,7 +44,7 @@ public partial class EntityDebugger : Control
         if (index > 0 && index < World.WorldSize)
         {
             worldOptions.CurrentTab = index;
-            selectedEntity = EntityReference.Null;
+            selectedEntity = Entity.Null;
             entityDetailsTree.Clear();
             ClearEntityListTree();
         }
@@ -54,7 +54,7 @@ public partial class EntityDebugger : Control
     /// Selects an entity in the details tree
     /// </summary>
     /// <param name="entity"></param>
-    public void SelectEntity(EntityReference entity)
+    public void SelectEntity(Entity entity)
     {
         if (selectedEntity != entity)
         {
@@ -174,11 +174,11 @@ public partial class EntityDebugger : Control
 
         foreach (ref Archetype archetype in ActiveWorld)
         {
-            if (!ArchetypeManager.TryGetArchetypeDisplayName(archetype.Types, out string archetypeKey))
+            if (!ArchetypeManager.TryGetArchetypeDisplayName(archetype.Signature, out string archetypeKey))
             {
                 stringBuilder.Clear();
 
-                foreach (Arch.Core.Utils.ComponentType type in archetype.Types)
+                foreach (Arch.Core.Utils.ComponentType type in archetype.Signature)
                 {
                     stringBuilder.Append(type.Type.Name).Append(", ");
                 }
@@ -237,7 +237,7 @@ public partial class EntityDebugger : Control
                 foreach (int index in chunk)
                 {
                     Entity entity = chunk.Entities[index];
-                    string entityIdKey = $"{entity.Id} | {entity.Version()}";
+                    string entityIdKey = $"{entity.Id} | {entity.Version}";
                     currentEntities.Add(entityIdKey);
 
                     if (!entityItems.ContainsKey(entityIdKey))
@@ -249,7 +249,7 @@ public partial class EntityDebugger : Control
                     }
 
                     TreeItem entityItem = entityItems[entityIdKey];
-                    if (entity == selectedEntity.Entity)
+                    if (entity == selectedEntity)
                     {
                         entityListTree.Disconnect("item_selected", Callable.From(OnEntitySelected));
                         entityItem.Select(0);
@@ -282,7 +282,7 @@ public partial class EntityDebugger : Control
         }
         Variant selectedMetadata = selected.GetMetadata(0);
         Entity entity = FindEntityById((int)selectedMetadata);
-        SelectEntity(entity.Reference());
+        SelectEntity(entity);
     }
 
     private void OnEntityComponentButtonClicked(TreeItem item, int buttonId, int column, int mouseButtonIndex)
@@ -294,7 +294,7 @@ public partial class EntityDebugger : Control
             if (buttonId == 0)
             {
                 Entity entity = FindEntityById(entityId);
-                SelectEntity(entity.Reference());
+                SelectEntity(entity);
             }
             if (buttonId == 1)
             {
@@ -330,7 +330,7 @@ public partial class EntityDebugger : Control
             return;
         }
 
-        Entity entity = selectedEntity.Entity;
+        Entity entity = selectedEntity;
 
         TreeItem entityRoot = entityDetailsTree.GetRoot();
 
@@ -342,7 +342,7 @@ public partial class EntityDebugger : Control
             else
                 archetypeName = "Entity";
 
-            entityRoot.SetText(0, $"{archetypeName} | ID: {entity.Id} | Version: {entity.Version()}");
+            entityRoot.SetText(0, $"{archetypeName} | ID: {entity.Id} | Version: {entity.Version}");
         }
 
         object[] components = entity.GetAllComponents();

--- a/Arch Entity Debugger/Scripts/Renderers/EntityRenderer.cs
+++ b/Arch Entity Debugger/Scripts/Renderers/EntityRenderer.cs
@@ -4,14 +4,14 @@ using Arch.Core;
 using Arch.Core.Extensions;
 using Godot;
 
-[EntityRenderer(typeof(EntityReference))]
-public class EntityReferenceRenderer : IEntityTreeRenderer
+[EntityRenderer(typeof(Entity))]
+public class EntityRenderer : IEntityTreeRenderer
 {
     static readonly Color refColor = new("#89B0F1");
 
     public void Render(bool isNew, TreeItem rootItem, object component, string fieldName)
     {
-        EntityReference entityRef = (EntityReference)component;
+        Entity entity = (Entity)component;
 
         if (isNew)
         {
@@ -19,28 +19,27 @@ public class EntityReferenceRenderer : IEntityTreeRenderer
             rootItem.AddButton(1, ResourceLoader.Load<Texture2D>("res://addons/Arch Entity Debugger/Assets/Icons/expand.png"));
         }
 
-        if (entityRef == EntityReference.Null || entityRef.Entity == Entity.Null)
+        if (entity == Entity.Null)
         {
             rootItem.SetText(0, $"{fieldName}: REF{{NULL}}");
             rootItem.SetCustomColor(0, Colors.IndianRed);
         }
-        else if (!entityRef.IsAlive())
+        else if (!entity.IsAlive())
         {
             rootItem.SetText(0, $"{fieldName}: REF{{INVALID}}");
             rootItem.SetCustomColor(0, Colors.MediumVioletRed);
         }
         else
         {
-            rootItem.SetText(0, $"{fieldName}: REF{{{entityRef.Entity.Id}}}");
+            rootItem.SetText(0, $"{fieldName}: REF{{{entity.Id}}}");
 
-            rootItem.SetMeta("ENTITY_REF", entityRef.Entity.Id);
+            rootItem.SetMeta("ENTITY_REF", entity.Id);
 
             bool expand = rootItem.HasMeta("EXPAND_ENTITY_REF") && (bool)rootItem.GetMeta("EXPAND_ENTITY_REF");
             if (expand)
             {
                 rootItem.SetCustomBgColor(0, new Color(refColor, 0.25f));
                 rootItem.ClearCustomColor(0);
-                Entity entity = entityRef.Entity;
 
                 object[] components = entity.GetAllComponents();
                 for (int i = 0; i < components.Length; i++)

--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ To do so add the Entity_Debugger_Hotkey_toggler.tscn scene and set the entityDeb
 Some public methods are exposed to allow you to control the debugger externally. You can show/hide the debugger, select an entity, or select an active world.
 
 - SetActive(int index) : Sets the window's visibility, and enables/disables processing of entities
-- SelectEntity(EntityReference entity) : Selects an entity in the details tree
+- SelectEntity(Entity entity) : Selects an entity in the details tree
 - SetWorld(int index) : Sets the active world to display entities from
 
 ## Customization / Extension


### PR DESCRIPTION
In Arch 2.0.0, `EntityReference` was removed, `Entity` is now used instead.