### PR TITLE
Updated using from Arch.Core.Utils to Arch.Core for ComponentType bug

### DIFF
--- a/Arch Entity Debugger/Scripts/ArchetypeManager.cs
+++ b/Arch Entity Debugger/Scripts/ArchetypeManager.cs
@@ -4,6 +4,7 @@ using Arch.Core.Utils;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Arch.Core;
 
 /// <summary>
 /// Manages the mapping between archetypes and their display names.

--- a/Arch Entity Debugger/Scripts/ComponentTypeArrayComparer.cs
+++ b/Arch Entity Debugger/Scripts/ComponentTypeArrayComparer.cs
@@ -3,6 +3,7 @@ namespace RoadTurtleGames.ArchEntityDebugger;
 using Arch.Core.Utils;
 using System.Collections.Generic;
 using System.Linq;
+using Arch.Core;
 
 /// <summary>
 /// Custom comparer for ComponentType arrays.

--- a/Arch Entity Debugger/Scripts/EntityDebugger.cs
+++ b/Arch Entity Debugger/Scripts/EntityDebugger.cs
@@ -178,7 +178,7 @@ public partial class EntityDebugger : Control
             {
                 stringBuilder.Clear();
 
-                foreach (Arch.Core.Utils.ComponentType type in archetype.Signature)
+                foreach (Arch.Core.ComponentType type in archetype.Signature)
                 {
                     stringBuilder.Append(type.Type.Name).Append(", ");
                 }


### PR DESCRIPTION
Fixes Issue with ComponentType being undefined. Arch moved ComponentType to Core from Core.Utils